### PR TITLE
nptime.nptime.__add__: [Fix] Play nicely with subclasses

### DIFF
--- a/nptime.py
+++ b/nptime.py
@@ -116,7 +116,7 @@ class nptime(time):
         """Add nptime and timedelta, returning an nptime"""
         self_dt = datetime.combine(self._std_date, self)
         sum = self_dt + other
-        return nptime.from_time(sum.time())
+        return self.from_time(sum.time())
 
     def __radd__(self, other):
         """Add timedelta and nptime"""


### PR DESCRIPTION
If `nptime` is subclassed, the current implementation of `__add__` will return an instance of `nptime.nptime` instead of an instance of the subclass. This is because the `from_time` call is made on `nptime` instead of on `self`. This commit changes this so that current functionality is maintained, but adding a subclass of `nptime.nptime` and a `timedelta` returns an instance of the `subclass`.

I can't get `tox` to pass - I don't have Python 3.3 on my system (I could use a VM or container) and I think the Sphinx config is out of date. (The first step - the actual tests - does pass.)
